### PR TITLE
Fixed scoping issue in Project.getConfigXml

### DIFF
--- a/src/Project.ts
+++ b/src/Project.ts
@@ -135,7 +135,7 @@ namespace CocoonSDK {
         }
 
         getConfigXml(callback: (xml: string, error: Error) => void) {
-            this.client.project.getConfigXml(this.data.config, function (xml: string, error: Error) {
+            this.client.project.getConfigXml(this.data.config, (xml: string, error: Error) => {
                 if (xml) {
                     this.cachedXml = xml;
                 }


### PR DESCRIPTION
The use of function () instead of ()=> caused 'this.cacheXml = xml' to throw an error in Project.getConfigXml() due to this not beeing available in the scope.